### PR TITLE
Add config example and Firebase CLI config (#3)

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "pokemon-sprint-generator-demo"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public/config.js
+.DS_Store

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,15 @@
+{
+  "hosting": {
+    "public": "public",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**",
+      "public/config.js"
+    ],
+    "rewrites": [{ "source": "**", "destination": "/index.html" }]
+  },
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/public/config.example.js
+++ b/public/config.example.js
@@ -1,0 +1,13 @@
+// Copy this to public/config.js and fill with your Firebase Web App credentials.
+// These are client-side values (not secrets). Security is enforced by Firestore rules.
+window.firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET.appspot.com",
+  messagingSenderId: "YOUR_SENDER_ID",
+  appId: "YOUR_APP_ID",
+};
+
+// Demo flags: keep writes disabled in the public demo.
+window.demo = { allowWrites: false };


### PR DESCRIPTION
### Summary

Add `public/config.example.js` to provide a safe client configuration pattern and ignore the real
`public/config.js`. Include `.firebaserc` (project alias: pokemon-sprint-generator-demo) and
`firebase.json` so the Firebase CLI can deploy Hosting and Firestore rules cleanly.

### Test plan

1. Copy example: `cp public/config.example.js public/config.js`
2. Paste demo Firebase Web App values into `public/config.js`
3. Run `git status` and confirm `public/config.js` is NOT staged (ignored by .gitignore)

### Linked Issue

Closes #3 

### Checklist

- [x] Issue linked (e.g. #3 )
- [x] Docs updated if needed
- [x] CI green / local tests pass
- [x] No secrets or personal data in diff
